### PR TITLE
Fix console output encoding

### DIFF
--- a/msfastbuild/msfastbuild.cs
+++ b/msfastbuild/msfastbuild.cs
@@ -263,7 +263,6 @@ namespace msfastbuild
 				FBProcess.StartInfo.RedirectStandardOutput = true;
 				FBProcess.StartInfo.UseShellExecute = false;
 				FBProcess.StartInfo.WorkingDirectory = projectDir;
-				FBProcess.StartInfo.StandardOutputEncoding = Console.OutputEncoding;
 
 				FBProcess.Start();
 				while (!FBProcess.StandardOutput.EndOfStream)

--- a/msfastbuildvsix/FASTBuild.cs
+++ b/msfastbuildvsix/FASTBuild.cs
@@ -10,6 +10,7 @@ using System.Reflection;
 using System.IO;
 using EnvDTE;
 using EnvDTE80;
+using System.Text;
 
 namespace msfastbuildvsix
 {
@@ -181,6 +182,7 @@ namespace msfastbuildvsix
                 FBProcess.StartInfo.RedirectStandardOutput = true;
                 FBProcess.StartInfo.UseShellExecute = false;
                 FBProcess.StartInfo.CreateNoWindow = true;
+                FBProcess.StartInfo.StandardOutputEncoding = Encoding.GetEncoding("ibm850");
 
                 System.Diagnostics.DataReceivedEventHandler OutputEventHandler = (Sender, Args) => {
                     if (Args.Data != null)


### PR DESCRIPTION
It fixes the issue as the output encoding in the plugin seems to be "windows-1252".
