### PR TITLE
Fixed ignored project references

### DIFF
--- a/msfastbuild/msfastbuild.cs
+++ b/msfastbuild/msfastbuild.cs
@@ -205,7 +205,7 @@ namespace msfastbuild
 							var ProjectReferences = proj.Items.Where(elem => elem.ItemType == "ProjectReference");
 							foreach (var ProjRef in ProjectReferences)
 							{
-								if (ProjRef.GetMetadataValue("ReferenceOutputAssembly") == "true")
+								if (ProjRef.GetMetadataValue("ReferenceOutputAssembly") == "true" || ProjRef.GetMetadataValue("LinkLibraryDependencies") == "true")
 								{
 									//Console.WriteLine(string.Format("{0} referenced by {1}.", Path.GetFileNameWithoutExtension(ProjRef.EvaluatedInclude), Path.GetFileNameWithoutExtension(proj.FullPath)));
 									EvaluateProjectReferences(Path.GetDirectoryName(proj.FullPath) + Path.DirectorySeparatorChar + ProjRef.EvaluatedInclude, evaluatedProjects, newProj);


### PR DESCRIPTION
Our solution file uses project references and builds correctly in visual studio, however, I got linking errors when creating the bff files using msfastbuild. This change causes project references to be included when LinkLibraryDependencies is enabled for the project reference.

Please find a test case using the projectreferences solution here: https://github.com/TheClassic/msfastbuildTests