### PR TITLE
Remove newline from linker options

### DIFF
--- a/msfastbuild/msfastbuild.cs
+++ b/msfastbuild/msfastbuild.cs
@@ -632,7 +632,13 @@ namespace msfastbuild
 				{
 					LinkerOptions += CurrentProject.AdditionalLinkInputs;
 				}
-				OutputString.AppendFormat("\t.LinkerOptions = '\"%1\" /OUT:\"%2\" {0}'\n", LinkerOptions.Replace("'","^'"));
+				
+				LinkerOptions = LinkerOptions
+					.Replace("'", "^'")
+					.Replace("\n", string.Empty)
+					.Replace("\r", string.Empty);
+
+				OutputString.AppendFormat("\t.LinkerOptions = '\"%1\" /OUT:\"%2\" {0}'\n", LinkerOptions);
 				OutputString.AppendFormat("\t.LinkerOutput = '{0}'\n", OutputFile);
 
 				OutputString.Append("\t.Libraries = { ");


### PR DESCRIPTION
I have a few property sheets where dependencies are listed on newlines like this:

```
...
    <Link>
      <AdditionalDependencies>
$(LibDir)\Lib1.lib;
$(LibDir)\Lib2.lib;
$(LibDir)\Lib3.lib;
    </AdditionalDependencies>
  </link>
...
```

The resulting `bff` file was messed up, resulting in a linker error.
Stripping newlines from the linker options fixed the problem.